### PR TITLE
DEPLOY: Use hosts TimeZone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       network: host
     secrets:
       - config.toml
+    volumes:
+      - "/etc/localtime:/etc/localtime:ro"
 
 secrets:
   config.toml:


### PR DESCRIPTION
without specifying the timezone, the system defaults to (for example) UTC, which means we're late for beers, and that's a disaster!